### PR TITLE
chore: Use `ubuntu-latest` for auto-pkg-maintenance runner

### DIFF
--- a/.github/workflows/auto-pkg-maintenance.yaml
+++ b/.github/workflows/auto-pkg-maintenance.yaml
@@ -41,7 +41,7 @@ name: Auto Package Maintenance
 
 jobs:
   auto-pkg-maintenance:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
since ubuntu 20.04 is no longer supported and so that we don't have to do this dance again.